### PR TITLE
feat: expect newField from provider

### DIFF
--- a/consumer_code/pact.test.js
+++ b/consumer_code/pact.test.js
@@ -47,21 +47,21 @@ describe("tests with Pact", () => {
   });
 
   it("tests consumer b", () => {
-    const expectedProduct = {
-      id: "10",
-      type: "CREDIT_CARD",
-      name: "28 Degrees",
-      price: 30.0,
-    };
-
-    // // Uncomment the below expectedProduct to see a failure
     // const expectedProduct = {
     //   id: "10",
     //   type: "CREDIT_CARD",
     //   name: "28 Degrees",
     //   price: 30.0,
-    //   newField: 22,
     // };
+
+    // // Uncomment the below expectedProduct to see a failure
+    const expectedProduct = {
+      id: "10",
+      type: "CREDIT_CARD",
+      name: "28 Degrees",
+      price: 30.0,
+      newField: 22,
+    };
     providerWithConsumerB
       .given("products exist")
       .uponReceiving("A request to get all products")


### PR DESCRIPTION
Consumer B requires a field that the provider(s) currently deployed into the `test` environment do not support and therefore this can-i-deploy check will fail for consumer b, but pass for consumer a.

_DO NOT MERGE: Demo purposes only_