### PR TITLE
feat: remove name field from Provider OAS

### DIFF
--- a/oas/swagger.yaml
+++ b/oas/swagger.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.1
 info:
   title: Product API
   description: Pactflow Product API demo
-  version: 1.0.0
+  version: 1.0.1
 servers:
 - url: /
 paths:
@@ -45,7 +45,6 @@ paths:
                   id: "1234"
                   type: food
                   price: 42
-                  name: burger
         required: true
       responses:
         "200":
@@ -60,7 +59,6 @@ paths:
                     id: "1234"
                     type: food
                     price: 42
-                    name: burger
   /product/{id}:
     get:
       summary: Find product by ID
@@ -100,15 +98,12 @@ components:
     Product:
       required:
       - id
-      - name
       - price
       type: object
       properties:
         id:
           type: string
         type:
-          type: string
-        name:
           type: string
         version:
           type: string


### PR DESCRIPTION
The author in SwaggerHub has updated the OpenAPI specification, removing a field from the response body.

The AutoMock's functional tests pass, which would give the provider confidence in the change on their side, but Pactflow provides visibility into the consumers expectations, showing that this change would impact consumers, and cause breaking changes, as well as which teams to talk to.

The Author may then choose to propose an alternative change.

_DO NOT MERGE: Demo purposes only_